### PR TITLE
added more verbose output to variable dimension mismatch error

### DIFF
--- a/ncio.f90
+++ b/ncio.f90
@@ -28,7 +28,7 @@ module ncio
 
     double precision, parameter :: NCIO_VERSION = 0.2d0
 
-    integer, parameter :: NC_STRLEN = 256 
+    integer, parameter :: NC_STRLEN = 256
     integer, parameter :: NC_STRLEN_MAX = 10000
     character(len=2)   :: NC_STR_SEP = "; "
     double precision, parameter :: NC_TOL = 1d-7
@@ -53,7 +53,7 @@ module ncio
     interface nc_write
         module procedure    nc_write_int_pt, &
                             nc_write_int_1D, nc_write_int_2D, &
-                            nc_write_int_3D, nc_write_int_4D  
+                            nc_write_int_3D, nc_write_int_4D
         module procedure    nc_write_double_pt, &
                             nc_write_double_1D, nc_write_double_2D, &
                             nc_write_double_3D, nc_write_double_4D, &
@@ -64,34 +64,34 @@ module ncio
         module procedure    nc_write_logical_pt, &
                             nc_write_logical_1D, nc_write_logical_2D, &
                             nc_write_logical_3D, nc_write_logical_4D
-        
-        ! Note: character writing and reading do not 
+
+        ! Note: character writing and reading do not
         ! follow the conventions of the other data types
         module procedure    nc_write_internal_char, &
                             nc_write_char_1D, nc_write_char_2D, &
                             nc_write_char_3D, nc_write_char_4D   ! Dummy procedures
-    
-    end interface  
 
-    interface nc_read 
+    end interface
+
+    interface nc_read
         module procedure    nc_read_int_pt, &
                             nc_read_int_1D, nc_read_int_2D, &
                             nc_read_int_3D, nc_read_int_4D, &
-                            nc_read_int_5D, nc_read_int_6D 
+                            nc_read_int_5D, nc_read_int_6D
         module procedure    nc_read_double_pt, &
                             nc_read_double_1D, nc_read_double_2D, &
                             nc_read_double_3D, nc_read_double_4D, &
-                            nc_read_double_5D, nc_read_double_6D 
+                            nc_read_double_5D, nc_read_double_6D
         module procedure    nc_read_float_pt, &
                             nc_read_float_1D, nc_read_float_2D, &
                             nc_read_float_3D, nc_read_float_4D, &
-                            nc_read_float_5D, nc_read_float_6D  
+                            nc_read_float_5D, nc_read_float_6D
         module procedure    nc_read_logical_pt, &
                             nc_read_logical_1D, nc_read_logical_2D, &
                             nc_read_logical_3D, nc_read_logical_4D, &
-                            nc_read_logical_5D, nc_read_logical_6D                    
+                            nc_read_logical_5D, nc_read_logical_6D
 
-        ! Note: character writing and reading do not 
+        ! Note: character writing and reading do not
         ! follow the conventions of the other data types
         module procedure    nc_read_internal_char, &
                             nc_read_char_1D
@@ -103,18 +103,18 @@ module ncio
         module procedure    nc_write_dim_float_pt, nc_write_dim_float_1D
     end interface
 
-    interface nc_write_attr 
+    interface nc_write_attr
         module procedure    nc_write_attr_global, nc_write_attr_variable
-    end interface 
+    end interface
 
-    interface nc_read_attr 
+    interface nc_read_attr
         module procedure    nc_read_attr_global, nc_read_attr_variable
-    end interface 
-    
+    end interface
+
     private
-    public :: nc_read, nc_read_attr  
+    public :: nc_read, nc_read_attr
     public :: nc_create, nc_write_map, nc_write_dim
-    public :: nc_open, nc_close 
+    public :: nc_open, nc_close
     public :: nc_write, nc_write_attr, nc_size
 
     public :: nc_dims, nc_ndims, nc_dimnames
@@ -127,14 +127,14 @@ contains
 !   INTERNAL WRITE/READ FUNCTIONS
 !
 ! =================================
-    
+
     subroutine nc4_write_internal(filename,name,dat,xtype,size_in,&
                                   ncid,dims,dim1,dim2,dim3,dim4,dim5,dim6, &
                                   start,count,long_name,standard_name,grid_mapping,units, &
                                   missing_value_int,missing_value_float,missing_value_double)
-                        
 
-        implicit none 
+
+        implicit none
 
         type(ncvar) :: v
 
@@ -150,8 +150,8 @@ contains
         integer :: size_in(:)
         integer, allocatable :: size_var(:)
 
-        integer, optional :: ncid 
-        integer :: nc_id 
+        integer, optional :: ncid
+        integer :: nc_id
 
         ! netCDF needed counters, array, and names of dims
         integer :: stat, ncount, nvar, RecordDimID
@@ -169,21 +169,21 @@ contains
         if ( present(grid_mapping) )  v%grid_mapping  = trim(grid_mapping)
         if ( present(units) )         v%units         = trim(units)
 
-        if (present(missing_value_int)) then 
+        if (present(missing_value_int)) then
             v%missing_set = .TRUE.
             v%missing_value = dble(missing_value_int)
-        else if (present(missing_value_float)) then 
+        else if (present(missing_value_float)) then
             v%missing_set = .TRUE.
             v%missing_value = dble(missing_value_float)
-        else if (present(missing_value_double)) then 
+        else if (present(missing_value_double)) then
             v%missing_set = .TRUE.
             v%missing_value = missing_value_double
-        end if 
+        end if
 
         ! Open the file in write mode from filename or ncid
         call nc_check_open(filename, ncid, nf90_write, nc_id)
         ! and get attributes if variable already exist
-        call nc_get_att(nc_id,v)    
+        call nc_get_att(nc_id,v)
         call nc_check( nf90_inquire(nc_id, unlimitedDimID=RecordDimID) ) ! Get Unlimited dimension ID if any
 
         ! Determine number of dims in file from arguments
@@ -202,7 +202,7 @@ contains
             if (present(dim4)) ndims = 4
             if (present(dim5)) ndims = 5
             if (present(dim6)) ndims = 6
-        end if 
+        end if
 
         ! Allocate dimensions of variable on file
         if (allocated(v%dims)) deallocate(v%dims)
@@ -210,9 +210,9 @@ contains
         if (present(dims)) then
             do i = 1, ndims
                 v%dims(i) = trim(dims(i))
-            end do 
+            end do
         else
-            do i = 1, ndims 
+            do i = 1, ndims
                 select case(i)
                     case(1)
                         v%dims(i) = trim(dim1)
@@ -246,14 +246,14 @@ contains
         v%count = 1
         if (present(count)) then
             ! Assign argument as count
-            v%count = count   
+            v%count = count
         else if (size(dat) .eq. nvar) then
             ! Assign count from size of variable on file
-            v%count = size_var 
+            v%count = size_var
         else
             ! Assign count from input dimension size
-            v%count(1:size(size_in)) = size_in 
-        end if 
+            v%count(1:size(size_in)) = size_in
+        end if
 
         ! Reset or initialize the actual range of the variable
         actual_range = [minval(dat),maxval(dat)]
@@ -265,9 +265,9 @@ contains
                 v%actual_range = actual_range
             end if
 !         end if
-        
+
         ! Check if the variable gave us reasonable values
-        if (maxval(dabs(v%actual_range)) .gt. 1d98) then 
+        if (maxval(dabs(v%actual_range)) .gt. 1d98) then
             write(*,*) "ncio:: nc_write:: warning: actual range too high,&
                             & variable may not be defined: "//trim(v%name)
             v%actual_range = [0.d0,0.d0]
@@ -277,37 +277,37 @@ contains
         if (trim(v%xtype) .eq. "NF90_FLOAT" .or. trim(v%xtype) .eq. "NF90_DOUBLE") then
             if (v%missing_set) then
                 where( dabs(dat-v%missing_value) .gt. NC_TOL ) dat = (dat-v%add_offset)/v%scale_factor
-            else    
+            else
                 ! Apply the scalar and offset if available
                 dat = (dat-v%add_offset)/v%scale_factor
             end if
         end if
-        
-        ! Summarize what we'll do (diagnostics!!)  
+
+        ! Summarize what we'll do (diagnostics!!)
 !         call nc_print_attr(v)
 !         write(*,*) "ubound(dat): ",ubound(dat)
 !         write(*,*) "size(dat):   ",size(dat)
 !         write(*,*) "dat range:",minval(dat),maxval(dat)
-!         write(*,*) "start:",v%start 
-!         write(*,*) "count:",v%count 
-!         write(*,*) "size_in:",size_in 
+!         write(*,*) "start:",v%start
+!         write(*,*) "count:",v%count
+!         write(*,*) "size_in:",size_in
 !         write(*,*) "shape dat:",shape(dat)
 
         ! Make sure count size makes sense
         ncount = 1
-        do i = 1, ndims 
+        do i = 1, ndims
             ncount = ncount*v%count(i)
-        end do 
+        end do
         if (size(dat) .ne. ncount) then
             write(*,*) "ncio:: error: "// &
                        "The input variable size does not match the count of values to write to file."
             write(*,*) trim(filename)//": "//trim(v%name)
             write(*,*) "Size of variable: ",size(dat)
-            write(*,*) "Size of count:    ",ncount 
-            write(*,*) "start: ",start 
-            write(*,*) "count: ",count 
+            write(*,*) "Size of count:    ",ncount
+            write(*,*) "start: ",start
+            write(*,*) "count: ",count
             stop
-        end if 
+        end if
 
         ! Open the file
 !         call nc_check( nf90_open(filename, nf90_write, nc_id) )
@@ -321,16 +321,16 @@ contains
 
             call nc_check( nf90_inquire_dimension(nc_id, dimid, len=size_var(i)) )
 
-            if (v%count(i) .gt. size_var(i)) then 
+            if (v%count(i) .gt. size_var(i)) then
                 write(*,*) "ncio:: error: "// &
                            "count exceeds this dimension length."
                 write(*,*) trim(filename)//": "//trim(v%name)
                 write(*,*) "Dimension exceeded: ",trim(v%dims(i)), size_var(i)," < ",v%count(i)
                 write(*,*) "Are the data values a different shape than the file dimensions?"
                 write(*,*) "   In that case, specify start+count as arguments."
-                stop 
-            end if 
-        end do 
+                stop
+            end if
+        end do
 
         ! Define / update the netCDF variable for the data.
         call nc_check( nf90_redef(nc_id) )
@@ -346,8 +346,8 @@ contains
         if (.not. present(ncid)) call nc_check( nf90_close(nc_id) )
 
 !         write(*,"(a,a,a14)") "ncio:: nc_write:: ",trim(filename)//" : ",trim(v%name)
-        
-        return 
+
+        return
 
     end subroutine nc4_write_internal
 
@@ -379,7 +379,7 @@ contains
         character (len=NC_STRLEN) :: tmpstr
         integer :: i
 
-        ! Open the file. 
+        ! Open the file.
         call nc_check_open(filename, ncid, nf90_nowrite, nc_id)
 
         ! TO DO: Add check to make sure variable exists !!!!
@@ -388,34 +388,34 @@ contains
         ! Initialize the netcdf variable info and load attributes
         call nc_v_init(v,name)
         call nc_get_att(nc_id,v,readmeta=.TRUE.)
-        v%xtype = trim(xtype) 
+        v%xtype = trim(xtype)
 
         ! Get variable dimension
         ndims = size(v%dims)
 
         if (present(start)) then
             allocate(v%start(size(start)))
-            v%start = start 
-        else 
+            v%start = start
+        else
             allocate(v%start(ndims))
             v%start(:) = 1
-        end if 
+        end if
 
         if (present(count)) then
             allocate(v%count(size(count)))
-            v%count = count 
-        else 
-            if (.not. ndims .eq. size(size_in)) then 
+            v%count = count
+        else
+            if (.not. ndims .eq. size(size_in)) then
                 write(*,"(a)") "nc_read:: ","Warning: "// &
                 "Variable dimensions in the file do not match those being read in."
                 write(*,*) trim(filename)//": ",trim(name)
-            end if 
+            end if
             allocate(v%count(ndims))
-            v%count = 1 
+            v%count = 1
             do i = 1, size(size_in)
               v%count(i) = size_in(i)
             end do
-        end if 
+        end if
 
         ! Read the variable data from the file
         ! (NF90 converts dat to proper type (int, real, dble)
@@ -424,11 +424,11 @@ contains
         ! Close the file. This frees up any internal netCDF resources
         ! associated with the file.
         if (.not. present(ncid)) call nc_check( nf90_close(nc_id) )
-        
+
         if (v%missing_set) then
             where( dabs(dat-v%missing_value) .gt. NC_TOL ) dat = dat*v%scale_factor + v%add_offset
 
-            ! Fill with user-desired missing value 
+            ! Fill with user-desired missing value
             if (present(missing_value_int)) &
                 where( dabs(dat-v%missing_value) .le. NC_TOL ) dat = dble(missing_value_int)
             if (present(missing_value_float)) &
@@ -436,14 +436,14 @@ contains
             if (present(missing_value_double)) &
                 where( dabs(dat-v%missing_value) .le. NC_TOL ) dat = dble(missing_value_double)
 
-        else    
+        else
             ! Apply the scalar and offset if available
             if (v%scale_factor .ne. 1.d0 .and. v%add_offset .ne. 0.d0) &
               dat = dat*v%scale_factor + v%add_offset
         end if
 
         ! Also eliminate crazy values (in case they are not handled by missing_value for some reason)
-        ! Fill with user-desired missing value 
+        ! Fill with user-desired missing value
         if (present(missing_value_int)) &
             where( dabs(dat) .ge. NC_LIM ) dat = dble(missing_value_int)
         if (present(missing_value_float)) &
@@ -460,39 +460,39 @@ contains
     ! Open a netcdf file and return a valid ncid
     subroutine nc_open(filename,ncid,writable)
 
-        implicit none 
+        implicit none
 
-        character(len=*) filename 
-        logical, optional :: writable 
-        logical :: is_writable 
-        integer :: ncid 
+        character(len=*) filename
+        logical, optional :: writable
+        logical :: is_writable
+        integer :: ncid
 
-        is_writable = .TRUE. 
+        is_writable = .TRUE.
         if (present(writable)) is_writable = writable
 
-        if (is_writable) then 
+        if (is_writable) then
             call nc_check( nf90_open(filename, nf90_write, ncid) )
-        else 
+        else
             call nc_check( nf90_open(filename, nf90_nowrite, ncid) )
-        end if 
+        end if
 
-        return 
+        return
 
-    end subroutine nc_open 
+    end subroutine nc_open
 
     ! Close a netcdf file returning the ncid=0
     subroutine nc_close(ncid)
 
-        implicit none 
+        implicit none
 
-        integer :: ncid 
+        integer :: ncid
         call nc_check( nf90_close(ncid) )
 
-        ncid = 0 
+        ncid = 0
 
-        return 
+        return
 
-    end subroutine nc_close 
+    end subroutine nc_close
 
     !! ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     !! Subroutine :  nc_v_init
@@ -508,10 +508,10 @@ contains
 
         character(len=*) :: name
         character(len=*), optional :: xtype
-        integer,          optional :: ndims_in 
+        integer,          optional :: ndims_in
         character(len=*), optional :: long_name, standard_name
         character(len=*), optional :: grid_mapping, units, axis, calendar
-        logical, optional :: coord 
+        logical, optional :: coord
 
         integer :: i
 
@@ -531,11 +531,11 @@ contains
         v%FillValue_set = .FALSE.
 
         v%xtype = "NF90_DOUBLE"
-        v%coord = .FALSE. 
+        v%coord = .FALSE.
 
         v%grid_mapping  = ""
 
-        ! If args are present, reassign these variables        
+        ! If args are present, reassign these variables
         if ( present(long_name) )     v%long_name      = trim(long_name)
         if ( present(grid_mapping) )  v%grid_mapping   = trim(grid_mapping)
         if ( present(units) )         v%units          = trim(units)
@@ -543,7 +543,7 @@ contains
         if ( present(calendar) .and. trim(name) == "time" )  &
                                       v%calendar       = trim(calendar)
 
-        if ( present(coord)) v%coord = coord 
+        if ( present(coord)) v%coord = coord
         if ( present(xtype)) v%xtype = trim(xtype)
 
         ! Deallocate all arrays
@@ -553,16 +553,16 @@ contains
 
         do i = 1, 4
             v%dims_in(i) = ""
-        end do 
-        v%ndims_in = 0 
-        if (present(ndims_in)) v%ndims_in = ndims_in 
+        end do
+        v%ndims_in = 0
+        if (present(ndims_in)) v%ndims_in = ndims_in
 
         return
 
     end subroutine nc_v_init
 
     !
-    ! Write attributes for standard dimensions found in a netCDF file 
+    ! Write attributes for standard dimensions found in a netCDF file
     ! (if attribute not already defined)
     !
     subroutine nc_write_attr_std_dim(filename, ncid)
@@ -585,13 +585,13 @@ contains
 
             ! Check whether a dimension corresponds to this ID
             ! exit loop if not
-            stat = nf90_inquire_dimension(nc_id,i,name=name) 
+            stat = nf90_inquire_dimension(nc_id,i,name=name)
             if ( stat .ne. NF90_NOERR) then
                 exit
             endif
 
             ! Check whether a variable is associated with this dimension
-            stat = nf90_inq_varid(nc_id, trim(name), varid) 
+            stat = nf90_inq_varid(nc_id, trim(name), varid)
             if ( varid .ne. NF90_NOERR) cycle ! if dimension is not defined as variable, skip it
 
             ! Update some variable info based on further default cases
@@ -649,7 +649,7 @@ contains
 
         ! Try to retrieve attribute
         stat = nf90_get_att(ncid, varid, name, tmpstr)
-    
+
         ! Write new attribute only if not already defined
         if ( stat .ne. NF90_NOERR) then
             call nc_check( nf90_put_att(ncid, varid, name, value) )
@@ -670,12 +670,12 @@ contains
         integer, intent ( in) :: status
         integer, intent (out), optional :: stat
 
-        if(status /= nf90_noerr .and. (.not. present(stat)) ) then 
+        if(status /= nf90_noerr .and. (.not. present(stat)) ) then
             write(*,*) "ncio:: error: "//trim(nf90_strerror(status))
             stop "stopped by ncio."
         end if
 
-        if (present(stat)) then 
+        if (present(stat)) then
             stat = 0
             if(status /= nf90_noerr) stat = -1
         end if
@@ -699,7 +699,7 @@ contains
 
         nc_check_att = noerr
 
-        if(status /= nf90_noerr) then 
+        if(status /= nf90_noerr) then
             if (trim(nf90_strerror(status)) .eq. "NetCDF: Attribute not found") then
                 nc_check_att = -1
             else
@@ -708,7 +708,7 @@ contains
             end if
         end if
 
-        return 
+        return
 
     end function nc_check_att
 
@@ -721,30 +721,30 @@ contains
 
         character(len=*), optional, intent ( in) :: filename
         integer, optional, intent ( in) :: ncid
-        integer, intent (in) :: mode   
+        integer, intent (in) :: mode
         integer, intent (out) :: nc_id
 
         integer stat
 
-        ! Open the file. 
-        if (present(ncid)) then 
+        ! Open the file.
+        if (present(ncid)) then
           nc_id = ncid
         else
           if (.not. present(filename)) then
                 write(*, *) "ncio :: neither filename nor ncid provided, stop"
                 stop
           endif
-          stat = nf90_open(filename, mode, nc_id) 
+          stat = nf90_open(filename, mode, nc_id)
           if (stat .ne. NF90_NOERR) then
               write(*, *) "ncio :: error when opening file, no such file or directory? :: ",trim(filename)
               stop
           endif
-        end if 
+        end if
 
         return
 
     end subroutine nc_check_open
-  
+
     ! ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     ! Subroutine :  a t t r _ p r i n t
     ! Author     :  Alex Robinson
@@ -755,12 +755,12 @@ contains
         implicit none
 
         type(ncvar) :: v
-        integer :: i 
+        integer :: i
         character(len=512) :: dims_char
 
         write(dims_char,*) (trim(v%dims(i))//"  ", i=1,size(v%dims))
 
-        write(*,*) 
+        write(*,*)
         write(*,*) "nc_print_attr::"
         write(*,"(10x,a20,a1,2x,a)") "name", ":",trim(v%name)
         write(*,"(10x,a20,a1,2x,a)") "xtype",":",trim(v%xtype)
@@ -808,15 +808,15 @@ contains
 
         ! Define the variable if it doesn't exist
         if ( stat .ne. noerr ) then
-            
+
             ! Check if it's a dimension (coordinate) variable or a data variable
             ! Get the dimension ids for the variable to be defined
-            if ( v%coord ) then    
+            if ( v%coord ) then
                 ! This is a coordinate variable (ie, a dimension defintion)
                 ! Only one dimid needed (that of current variable)
                 allocate(dimids(1))
-                dimids(1) = v%dimid 
-            else 
+                dimids(1) = v%dimid
+            else
                 ! This is a data variable
                 ! Determine ids of dimensions
                 allocate(dimids(ndims))
@@ -837,15 +837,15 @@ contains
                     call nc_check( nf90_def_var(ncid,name=trim(v%name),xtype=NF90_CHAR,dimids=dimids,varid=v%varid) )
                 case DEFAULT
                     write(*,*) "nc_put_att:: Error, wrong xtype defined:"//trim(v%xtype)
-                    stop 
-            end select 
+                    stop
+            end select
 
             if (trim(v%xtype) .ne. "NF90_CHAR") then
-                    
-                    if (v%scale_factor .ne. 1.d0 .and. v%add_offset .ne. 0.d0) then 
+
+                    if (v%scale_factor .ne. 1.d0 .and. v%add_offset .ne. 0.d0) then
                         call nc_check( nf90_put_att(ncid, v%varid, "scale_factor", v%scale_factor) )
                         call nc_check( nf90_put_att(ncid, v%varid, "add_offset",   v%add_offset) )
-                    end if 
+                    end if
 
                     if (v%missing_set) then
                         select case(trim(v%xtype))
@@ -855,8 +855,8 @@ contains
                                 call nc_check( nf90_put_att(ncid, v%varid, "missing_value", real(v%missing_value)) )
                             case("NF90_DOUBLE")
                                 call nc_check( nf90_put_att(ncid, v%varid, "missing_value", v%missing_value) )
-                        end select 
-                    end if 
+                        end select
+                    end if
 
                     if (v%FillValue_set) then
                         select case(trim(v%xtype))
@@ -866,12 +866,12 @@ contains
                                 call nc_check( nf90_put_att(ncid, v%varid, "FillValue", real(v%FillValue)) )
                             case("NF90_DOUBLE")
                                 call nc_check( nf90_put_att(ncid, v%varid, "FillValue", v%FillValue) )
-                        end select 
-                    end if 
+                        end select
+                    end if
 
             end if
 
-            ! Add additional variable attributes 
+            ! Add additional variable attributes
 
             if (trim(v%long_name) .ne. "") &
                 call nc_check( nf90_put_att(ncid, v%varid, "long_name",     trim(v%long_name)) )
@@ -905,14 +905,14 @@ contains
                     v%actual_range = (/ 0.d0, 0.d0 /)
                 case DEFAULT
                     write(*,*) "nc_put_att:: Error, wrong xtype defined:"//trim(v%xtype)
-                    stop 
-            end select 
-        end if 
+                    stop
+            end select
+        end if
 
         return
 
     end subroutine nc_put_att
-  
+
     ! ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     ! Subroutine :  g e t _ a t t
     ! Author     :  Alex Robinson
@@ -924,7 +924,7 @@ contains
 
         integer :: ncid, stat, i
         double precision :: tmp, tmp2(2)
-        integer :: tmpi, tmpi2(2) 
+        integer :: tmpi, tmpi2(2)
 
         character(len=NC_STRLEN) :: tmpstr
         type(ncvar) :: v
@@ -934,18 +934,18 @@ contains
 
         integer, parameter :: noerr = NF90_NOERR
 
-        logical, optional :: readmeta 
-        logical :: read_meta 
+        logical, optional :: readmeta
+        logical :: read_meta
 
-        read_meta = .TRUE. 
-        if (present(readmeta)) read_meta = readmeta 
+        read_meta = .TRUE.
+        if (present(readmeta)) read_meta = readmeta
 
         ! Get the current variable's id, if it exists
         stat = nf90_inq_varid(ncid, trim(v%name), v%varid)
 
         ! If variable exists, get attributes from file
         if ( stat .eq. noerr ) then
-          
+
             ! Get number of dimensions and dimids
             call nc_check ( nf90_inquire_variable(ncid, v%varid, ndims=ndims) )
             if (allocated(dimids)) deallocate(dimids); allocate(dimids(ndims))
@@ -960,7 +960,7 @@ contains
                 call nc_check ( nf90_inquire_dimension(ncid,dimids(i),name=v%dims(i),len=v%dlen(i)) )
             end do
 
-            if ( read_meta ) then 
+            if ( read_meta ) then
                 stat = nc_check_att( nf90_get_att(ncid, v%varid, "units", tmpstr) )
                 if (stat .eq. noerr) v%units = trim(tmpstr)
 
@@ -992,7 +992,7 @@ contains
                         if (stat .eq. noerr) v%add_offset = dble(tmpi)
 
                         call nc_get_att_double(ncid,v%varid,"missing_value",v%missing_value,stat)
-                        if (stat .eq. noerr) v%missing_set = .TRUE. 
+                        if (stat .eq. noerr) v%missing_set = .TRUE.
 
                         stat = nc_check_att( nf90_get_att(ncid, v%varid, "FillValue", tmpi) )
                         if (stat .eq. noerr) then
@@ -1012,7 +1012,7 @@ contains
                         if (stat .eq. noerr) v%add_offset = tmp
 
                         call nc_get_att_double(ncid,v%varid,"missing_value",v%missing_value,stat)
-                        if (stat .eq. noerr) v%missing_set = .TRUE. 
+                        if (stat .eq. noerr) v%missing_set = .TRUE.
 
                         stat = nc_check_att( nf90_get_att(ncid, v%varid, "FillValue", tmp) )
                         if (stat .eq. noerr) then
@@ -1021,7 +1021,7 @@ contains
                         end if
 
                 end select
-            end if 
+            end if
 
         end if
 
@@ -1031,13 +1031,13 @@ contains
 
     subroutine nc_get_att_double(ncid,varid,name,val,stat)
 
-        implicit none 
+        implicit none
 
-        integer :: ncid, varid 
-        character(len=*) :: name  
-        double precision :: val 
-        integer :: stat, xtype, len 
-        character(len=256) :: val_s 
+        integer :: ncid, varid
+        character(len=*) :: name
+        double precision :: val
+        integer :: stat, xtype, len
+        character(len=256) :: val_s
 
         integer, parameter :: noerr = NF90_NOERR
 
@@ -1045,19 +1045,19 @@ contains
         if (stat .eq. noerr) then
 
             select case(xtype)
-                case(NF90_INT,NF90_FLOAT,NF90_DOUBLE,NF90_SHORT) 
+                case(NF90_INT,NF90_FLOAT,NF90_DOUBLE,NF90_SHORT)
                     stat = nf90_get_att(ncid, varid, trim(name), val)
                 case(NF90_CHAR)
                     stat = nf90_get_att(ncid, varid, trim(name), val_s(1:len))
-                    val = str_to_num(val_s(1:len)) 
+                    val = str_to_num(val_s(1:len))
                 case DEFAULT
                     write(*,*) "GET_ATT: "//trim(name)//": ",xtype, len
             end select
 
-        end if 
+        end if
 
         return
-    end subroutine nc_get_att_double 
+    end subroutine nc_get_att_double
 
     ! Return the size of a dimension in netcdf file
     function nc_size(filename,name,ncid)
@@ -1068,8 +1068,8 @@ contains
         integer :: dimid, dimlen, stat
         character (len=*) :: filename, name
 
-        integer, optional :: ncid 
-        integer :: nc_id 
+        integer, optional :: ncid
+        integer :: nc_id
 
         ! Open the file if needed
         call nc_check_open(filename, ncid, nf90_nowrite, nc_id)
@@ -1083,7 +1083,7 @@ contains
 
         ! Get the dimension length and close the file
         call nc_check( nf90_inquire_dimension(nc_id, dimid, len=dimlen) )
-        
+
         if (.not. present(ncid)) call nc_check( nf90_close(nc_id) )
 
         nc_size = dimlen
@@ -1114,7 +1114,7 @@ contains
 
         return
 
-    end function nc_ndims 
+    end function nc_ndims
 
     ! Return the dimension names of a given variable in a given file
     function nc_dimnames(filename,name,ndims) result(names)
@@ -1125,7 +1125,7 @@ contains
         character (len=32) :: names(ndims)
         integer :: nc_id, varid, ndims
         integer :: dimids(ndims)
-        integer :: q 
+        integer :: q
 
         ! Open the file
         call nc_check_open(filename, mode=nf90_nowrite, nc_id=nc_id)
@@ -1135,7 +1135,7 @@ contains
         ! Get the dimension length and close the file
         do q = 1, size(dimids)
             call nc_check( nf90_inquire_dimension(nc_id, dimids(q), name=names(q)) )
-        end do 
+        end do
 
         ! Close the file
         call nc_check( nf90_close(nc_id) )
@@ -1151,11 +1151,11 @@ contains
 
         character (len=*),  intent(IN)  :: filename, name
         character (len=*), allocatable :: names(:)
-        integer, allocatable, optional :: dims(:) 
+        integer, allocatable, optional :: dims(:)
         integer, allocatable :: dimids(:), dims0(:)
         integer :: nc_id, varid, ndims, q
 
-        ! Deallocate input arrays 
+        ! Deallocate input arrays
         if (allocated(names))   deallocate(names)
         if (allocated(dimids))  deallocate(dimids)
         if (allocated(dims0))   deallocate(dims0)
@@ -1164,7 +1164,7 @@ contains
         call nc_check_open(filename, mode=nf90_nowrite, nc_id=nc_id)
         call nc_check( nf90_inq_varid(nc_id, name, varid) )
         call nc_check( nf90_inquire_variable(nc_id, varid, ndims=ndims) )
-            
+
         ! Allocate dim arrays
         allocate(names(ndims),dimids(ndims),dims0(ndims))
 
@@ -1174,17 +1174,17 @@ contains
         ! Get the dimension name and length
         do q = 1, size(dimids)
             call nc_check( nf90_inquire_dimension(nc_id, dimids(q), name=names(q), len=dims0(q)) )
-        end do 
+        end do
 
         ! Close the file
         call nc_check( nf90_close(nc_id) )
 
         ! Also return dim lengths if desired
-        if (present(dims)) then 
+        if (present(dims)) then
             if (allocated(dims))    deallocate(dims)
             allocate(dims(ndims))
-            dims = dims0 
-        end if 
+            dims = dims0
+        end if
 
         return
 
@@ -1197,7 +1197,7 @@ contains
     ! ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
     subroutine nc_create(filename, author, creation_date, institution, description)
 
-        implicit none 
+        implicit none
 
         character(len=*) :: filename
         integer :: ncid, status
@@ -1208,7 +1208,7 @@ contains
         write(history,"(a,f5.2)") "Dataset generated using ncio v", NCIO_VERSION
 
         ! Create the new empty file and close it (necessary to avoid errors with dim vars)
-        status = nf90_create(trim(adjustl(filename)), nf90_clobber, ncid) 
+        status = nf90_create(trim(adjustl(filename)), nf90_clobber, ncid)
         if (status .ne. NF90_NOERR) then
             write(*, *) "ncio :: error when creating file, no such file or directory? :: ",trim(filename)
             stop
@@ -1221,16 +1221,16 @@ contains
         if (present(description))   call nc_write_attr(filename, 'description', description)
 
         write(*,"(a,a)") "ncio:: nc_create   :: ",trim(filename)
-        
+
         return
 
     end subroutine nc_create
 
     subroutine nc_write_attr_global(filename,name,value,ncid)
 
-        implicit none 
+        implicit none
 
-        character(len=*) :: filename, name, value 
+        character(len=*) :: filename, name, value
         integer :: nc_id
         integer, optional, intent(in) :: ncid
 
@@ -1246,17 +1246,17 @@ contains
 
         write(*,"(a,a)") "ncio:: nc_write_attr:: ", &
                               trim(filename)//" : "//trim(name)//" = "//trim(value)
-        
+
         return
 
     end subroutine nc_write_attr_global
 
     subroutine nc_read_attr_global(filename,name,value, ncid)
 
-        implicit none 
+        implicit none
 
         character(len=*), intent(in) :: filename, name
-        character(len=*), intent(out) :: value 
+        character(len=*), intent(out) :: value
         integer, intent(in), optional :: ncid
         integer :: nc_id
 
@@ -1264,7 +1264,7 @@ contains
         call nc_check_open(filename, ncid, nf90_nowrite, nc_id)
         call nc_check( nf90_get_att(nc_id, NF90_GLOBAL,trim(name), value) )
         if (.not.present(ncid)) call nc_check( nf90_close(nc_id) )
-        
+
         return
 
     end subroutine nc_read_attr_global
@@ -1272,9 +1272,9 @@ contains
 
     subroutine nc_write_attr_variable(filename,varname,name,value, ncid)
 
-        implicit none 
+        implicit none
 
-        character(len=*) :: filename, varname, name, value 
+        character(len=*) :: filename, varname, name, value
         integer :: nc_id, varid, stat
         integer, parameter :: noerr = NF90_NOERR
         integer, intent(in), optional :: ncid
@@ -1293,17 +1293,17 @@ contains
 
         write(*,"(a,a)") "ncio:: nc_write_attr:: ", &
                               trim(filename)//", "//trim(varname)//" : "//trim(name)//" = "//trim(value)
-        
+
         return
 
     end subroutine nc_write_attr_variable
 
     subroutine nc_read_attr_variable(filename,varname,name,value, ncid)
 
-        implicit none 
+        implicit none
 
         character(len=*), intent(in) :: filename, varname, name
-        character(len=*), intent(out) :: value 
+        character(len=*), intent(out) :: value
         integer :: nc_id, varid, stat
         integer, optional :: ncid
 
@@ -1311,14 +1311,14 @@ contains
         stat = nf90_inq_varid(nc_id, trim(varname), varid)
         call nc_check( nf90_get_att(nc_id, varid ,trim(name), value) )
         if (.not.present(ncid)) call nc_check( nf90_close(nc_id) )
-        
+
         return
 
     end subroutine nc_read_attr_variable
 
     subroutine nc_write_map(filename,name,lambda,phi,x_e,y_n, ncid)
 
-        implicit none 
+        implicit none
 
         character(len=*) :: filename, name
 
@@ -1331,7 +1331,7 @@ contains
         ! Open the file, set for redefinition
         call nc_check_open(filename, ncid, nf90_write, nc_id)
         call nc_check( nf90_redef(nc_id) )
-        
+
         ! Check if grid mapping has been defined in this file
         ! (if not, define it according to input arguments)
         stat = nf90_inq_varid(nc_id, trim(name), varid)
@@ -1365,23 +1365,23 @@ contains
             end select
 
             write(*,"(a,a,a)") "ncio:: nc_write_map:: ",trim(filename)//" : ",trim(name)
-        
-        end if 
+
+        end if
 
         ! Close the file
         if (.not.present(ncid)) call nc_check( nf90_close(nc_id) )
 
-        return 
+        return
 
     end subroutine nc_write_map
 
     !> Write an integer value (one point) dimension to a NetCDF file.
     !! @param filename name of the NetCDF file in which to define dimension
     !! @param name name of the dimension to be defined in NetCDF file
-    !! @param x Fortran data type (point or vector) specifying values of dimension. 
+    !! @param x Fortran data type (point or vector) specifying values of dimension.
     !! If nx is present and size(x)==1, x specifies the starting point of the dimension variable
     !! @param dx distance between each dimension value (optional)
-    !! @param nx length of dimension variable (optional) 
+    !! @param nx length of dimension variable (optional)
     !! @param long_name NetCDF attribute, a long descriptive name of the variable (optional)
     !! @param standard_name NetCDF attribute specifying the CF convention standard name of the variable (optional)
     !! @param units NetCDF attribute of the units of the variable (optional)
@@ -1400,7 +1400,7 @@ contains
         integer, optional :: dx
         integer, optional :: nx
         double precision, allocatable :: xvec(:)
-        double precision :: dx_tmp 
+        double precision :: dx_tmp
 
         character(len=*):: filename, name
         character(len=*), optional :: long_name, standard_name, units, axis
@@ -1412,12 +1412,12 @@ contains
             allocate(xvec(nx))
             dx_tmp = 1.d0
             if (present(dx)) dx_tmp = dble(dx)
-            do i = 1, nx 
-                xvec(i) = x + (i-1)*dx_tmp 
-            end do 
+            do i = 1, nx
+                xvec(i) = x + (i-1)*dx_tmp
+            end do
         else
             allocate(xvec(1))
-            xvec(1) = x 
+            xvec(1) = x
         end if
 
         call nc_write_dim_internal(filename,name,"NF90_INT",xvec, &
@@ -1439,7 +1439,7 @@ contains
         integer :: x(:)
         character(len=*):: filename, name
         character(len=*), optional :: long_name, standard_name, units, axis
-        character(len=*), optional :: calendar 
+        character(len=*), optional :: calendar
 
         logical, optional :: unlimited
 
@@ -1449,7 +1449,7 @@ contains
 
         return
 
-    end subroutine nc_write_dim_int_1D 
+    end subroutine nc_write_dim_int_1D
 
     subroutine nc_write_dim_double_pt(filename,name,x,dx,nx, &
                                      long_name,standard_name,units,axis,calendar,unlimited,ncid)
@@ -1463,7 +1463,7 @@ contains
         double precision, optional :: dx
         integer, optional :: nx
         double precision, allocatable :: xvec(:)
-        double precision :: dx_tmp 
+        double precision :: dx_tmp
 
         character(len=*):: filename, name
         character(len=*), optional :: long_name, standard_name, units, axis
@@ -1473,13 +1473,13 @@ contains
         if (present(nx)) then
             allocate(xvec(nx))
             dx_tmp = 1.d0
-            if (present(dx)) dx_tmp = dx 
-            do i = 1, nx 
-                xvec(i) = x + (i-1)*dx_tmp 
-            end do 
+            if (present(dx)) dx_tmp = dx
+            do i = 1, nx
+                xvec(i) = x + (i-1)*dx_tmp
+            end do
         else
             allocate(xvec(1))
-            xvec(1) = x 
+            xvec(1) = x
         end if
 
         call nc_write_dim_internal(filename,name,"NF90_DOUBLE",xvec, &
@@ -1524,7 +1524,7 @@ contains
         real(4), optional :: dx
         integer, optional :: nx
         double precision, allocatable :: xvec(:)
-        double precision :: dx_tmp 
+        double precision :: dx_tmp
 
         character(len=*):: filename, name
         character(len=*), optional :: long_name, standard_name, units, axis
@@ -1535,13 +1535,13 @@ contains
         if (present(nx)) then
             allocate(xvec(nx))
             dx_tmp = 1.d0
-            if (present(dx)) dx_tmp = dble(dx) 
-            do i = 1, nx 
-                xvec(i) = x + (i-1)*dx_tmp 
-            end do 
+            if (present(dx)) dx_tmp = dble(dx)
+            do i = 1, nx
+                xvec(i) = x + (i-1)*dx_tmp
+            end do
         else
             allocate(xvec(1))
-            xvec(1) = x 
+            xvec(1) = x
         end if
 
         call nc_write_dim_internal(filename,name,"NF90_FLOAT",xvec, &
@@ -1564,7 +1564,7 @@ contains
         character(len=*):: filename, name
         character(len=*), optional :: long_name, standard_name, units, axis
         character(len=*), optional :: calendar
- 
+
         logical, optional :: unlimited
 
         call nc_write_dim_internal(filename,name,"NF90_FLOAT",x=dble(x), &
@@ -1601,7 +1601,7 @@ contains
         character(len=*), optional :: calendar
         character(len=14) :: tmpchar
 
-        logical, optional :: unlimited  
+        logical, optional :: unlimited
         logical :: unlimited_i
 
         type(ncvar) :: v
@@ -1620,7 +1620,7 @@ contains
         if ( present(standard_name) ) v%standard_name = trim(standard_name)
         if ( present(units) )         v%units         = trim(units)
         if ( present(axis) )          v%axis          = trim(axis)
-        if ( present(calendar) )      v%calendar      = trim(calendar) 
+        if ( present(calendar) )      v%calendar      = trim(calendar)
         if ( present(unlimited) )      unlimited_i    = unlimited
 
         !! Clear the variable dim vector and store/generate appropriate values
@@ -1655,7 +1655,7 @@ contains
         ! End define mode.
         call nc_check( nf90_enddef(nc_id) )
 
-        ! Put the variable's values in the file 
+        ! Put the variable's values in the file
         call nc_check( nf90_put_var(nc_id, v%varid, v%dim) )
 
         ! Close the file
@@ -1663,17 +1663,17 @@ contains
 
         tmpchar = trim(v%name)
         write(*,"(a,a,a14,i6)") "ncio:: nc_write_dim:: ",trim(filename)//" : ",adjustl(tmpchar),size(v%dim)
-        
+
         return
 
     end subroutine nc_write_dim_internal
 
 ! ================================
 !
-!      INTEGERS 
+!      INTEGERS
 !
 ! ================================
-    
+
     !> Write an integer value (one point) to a NetCDF file.
     !! @param filename name of the NetCDF file in which to write data
     !! @param dat Fortran data type of data to be written
@@ -1691,14 +1691,14 @@ contains
     subroutine nc_write_int_pt(filename,name,dat,ncid,dims,dim1,dim2,dim3,dim4,dim5,dim6,start,count, &
                                   long_name,standard_name,grid_mapping,units,missing_value)
 
-        implicit none 
+        implicit none
 
         ! Arguments
         integer :: dat
         integer, optional :: missing_value
 
         character (len=*) :: filename, name
-        integer, optional :: start(:), count(:),ncid 
+        integer, optional :: start(:), count(:),ncid
         character (len=*), optional :: dims(:), dim1, dim2, dim3, dim4, dim5, dim6
         character (len=*), optional :: long_name, standard_name, grid_mapping, units
 
@@ -1716,7 +1716,7 @@ contains
     subroutine nc_write_int_1D(filename,name,dat,ncid,dims,dim1,dim2,dim3,dim4,dim5,dim6,start,count, &
                                   long_name,standard_name,grid_mapping,units,missing_value)
 
-        implicit none 
+        implicit none
 
         ! Arguments
         integer :: dat(:)
@@ -1726,7 +1726,7 @@ contains
         integer, optional :: start(:), count(:),ncid
         character (len=*), optional :: dims(:), dim1, dim2, dim3, dim4, dim5, dim6
         character (len=*), optional :: long_name, standard_name, grid_mapping, units
-        double precision, allocatable :: dat1D(:) 
+        double precision, allocatable :: dat1D(:)
 
         allocate(dat1D(size(dat)))
         dat1D = pack(dble(dat),.TRUE.)    ! Pack here to avoid segmentation faults!
@@ -1744,7 +1744,7 @@ contains
     subroutine nc_write_int_2D(filename,name,dat,ncid,dims,dim1,dim2,dim3,dim4,dim5,dim6,start,count, &
                                   long_name,standard_name,grid_mapping,units,missing_value)
 
-        implicit none 
+        implicit none
 
         ! Arguments
         integer :: dat(:,:)
@@ -1754,7 +1754,7 @@ contains
         integer, optional :: start(:), count(:),ncid
         character (len=*), optional :: dims(:), dim1, dim2, dim3, dim4, dim5, dim6
         character (len=*), optional :: long_name, standard_name, grid_mapping, units
-        double precision, allocatable :: dat1D(:) 
+        double precision, allocatable :: dat1D(:)
 
         allocate(dat1D(size(dat)))
         dat1D = pack(dble(dat),.TRUE.)    ! Pack here to avoid segmentation faults!
@@ -1772,7 +1772,7 @@ contains
     subroutine nc_write_int_3D(filename,name,dat,ncid,dims,dim1,dim2,dim3,dim4,dim5,dim6,start,count, &
                                   long_name,standard_name,grid_mapping,units,missing_value)
 
-        implicit none 
+        implicit none
 
         ! Arguments
         integer :: dat(:,:,:)
@@ -1783,7 +1783,7 @@ contains
         character (len=*), optional :: dims(:), dim1, dim2, dim3, dim4, dim5, dim6
         character (len=*), optional :: long_name, standard_name, grid_mapping, units
 
-        double precision, allocatable :: dat1D(:) 
+        double precision, allocatable :: dat1D(:)
 
         allocate(dat1D(size(dat)))
         dat1D = pack(dble(dat),.TRUE.)    ! Pack here to avoid segmentation faults!
@@ -1801,7 +1801,7 @@ contains
     subroutine nc_write_int_4D(filename,name,dat,ncid,dims,dim1,dim2,dim3,dim4,dim5,dim6,start,count, &
                                   long_name,standard_name,grid_mapping,units,missing_value)
 
-        implicit none 
+        implicit none
 
         ! Arguments
         integer :: dat(:,:,:,:)
@@ -1811,7 +1811,7 @@ contains
         integer, optional :: start(:), count(:),ncid
         character (len=*), optional :: dims(:), dim1, dim2, dim3, dim4, dim5, dim6
         character (len=*), optional :: long_name, standard_name, grid_mapping, units
-        double precision, allocatable :: dat1D(:) 
+        double precision, allocatable :: dat1D(:)
 
         allocate(dat1D(size(dat)))
         dat1D = pack(dble(dat),.TRUE.)    ! Pack here to avoid segmentation faults!
@@ -1829,7 +1829,7 @@ contains
     subroutine nc_write_int_5D(filename,name,dat,ncid,dims,dim1,dim2,dim3,dim4,dim5,dim6,start,count, &
                                   long_name,standard_name,grid_mapping,units,missing_value)
 
-        implicit none 
+        implicit none
 
         ! Arguments
         integer :: dat(:,:,:,:,:)
@@ -1839,7 +1839,7 @@ contains
         integer, optional :: start(:), count(:),ncid
         character (len=*), optional :: dims(:), dim1, dim2, dim3, dim4, dim5, dim6
         character (len=*), optional :: long_name, standard_name, grid_mapping, units
-        double precision, allocatable :: dat1D(:) 
+        double precision, allocatable :: dat1D(:)
 
         allocate(dat1D(size(dat)))
         dat1D = pack(dble(dat),.TRUE.)    ! Pack here to avoid segmentation faults!
@@ -1857,7 +1857,7 @@ contains
     subroutine nc_write_int_6D(filename,name,dat,ncid,dims,dim1,dim2,dim3,dim4,dim5,dim6,start,count, &
                                   long_name,standard_name,grid_mapping,units,missing_value)
 
-        implicit none 
+        implicit none
 
         ! Arguments
         integer :: dat(:,:,:,:,:,:)
@@ -1867,7 +1867,7 @@ contains
         integer, optional :: start(:), count(:),ncid
         character (len=*), optional :: dims(:), dim1, dim2, dim3, dim4, dim5, dim6
         character (len=*), optional :: long_name, standard_name, grid_mapping, units
-        double precision, allocatable :: dat1D(:) 
+        double precision, allocatable :: dat1D(:)
 
         allocate(dat1D(size(dat)))
         dat1D = pack(dble(dat),.TRUE.)    ! Pack here to avoid segmentation faults!
@@ -1884,14 +1884,14 @@ contains
 
 ! ================================
 !
-!      DOUBLES 
+!      DOUBLES
 !
 ! ================================
-    
+
     subroutine nc_write_double_pt(filename,name,dat,ncid,dims,dim1,dim2,dim3,dim4,dim5,dim6,start,count, &
                                   long_name,standard_name,grid_mapping,units,missing_value)
 
-        implicit none 
+        implicit none
 
         ! Arguments
         double precision :: dat
@@ -1916,7 +1916,7 @@ contains
     subroutine nc_write_double_1D(filename,name,dat,ncid,dims,dim1,dim2,dim3,dim4,dim5,dim6,start,count, &
                                   long_name,standard_name,grid_mapping,units,missing_value)
 
-        implicit none 
+        implicit none
 
         ! Arguments
         double precision :: dat(:)
@@ -1926,7 +1926,7 @@ contains
         integer, optional :: start(:), count(:),ncid
         character (len=*), optional :: dims(:), dim1, dim2, dim3, dim4, dim5, dim6
         character (len=*), optional :: long_name, standard_name, grid_mapping, units
-        double precision, allocatable :: dat1D(:) 
+        double precision, allocatable :: dat1D(:)
 
         allocate(dat1D(size(dat)))
         dat1D = pack(dble(dat),.TRUE.)    ! Pack here to avoid segmentation faults!
@@ -1944,7 +1944,7 @@ contains
     subroutine nc_write_double_2D(filename,name,dat,ncid,dims,dim1,dim2,dim3,dim4,dim5,dim6,start,count, &
                                   long_name,standard_name,grid_mapping,units,missing_value)
 
-        implicit none 
+        implicit none
 
         ! Arguments
         double precision :: dat(:,:)
@@ -1954,7 +1954,7 @@ contains
         integer, optional :: start(:), count(:),ncid
         character (len=*), optional :: dims(:), dim1, dim2, dim3, dim4, dim5, dim6
         character (len=*), optional :: long_name, standard_name, grid_mapping, units
-        double precision, allocatable :: dat1D(:) 
+        double precision, allocatable :: dat1D(:)
 
         allocate(dat1D(size(dat)))
         dat1D = pack(dble(dat),.TRUE.)    ! Pack here to avoid segmentation faults!
@@ -1972,7 +1972,7 @@ contains
     subroutine nc_write_double_3D(filename,name,dat,ncid,dims,dim1,dim2,dim3,dim4,dim5,dim6,start,count, &
                                   long_name,standard_name,grid_mapping,units,missing_value)
 
-        implicit none 
+        implicit none
 
         ! Arguments
         double precision :: dat(:,:,:)
@@ -1983,7 +1983,7 @@ contains
         character (len=*), optional :: dims(:), dim1, dim2, dim3, dim4, dim5, dim6
         character (len=*), optional :: long_name, standard_name, grid_mapping, units
 
-        double precision, allocatable :: dat1D(:) 
+        double precision, allocatable :: dat1D(:)
 
         allocate(dat1D(size(dat)))
         dat1D = pack(dble(dat),.TRUE.)    ! Pack here to avoid segmentation faults!
@@ -2001,7 +2001,7 @@ contains
     subroutine nc_write_double_4D(filename,name,dat,ncid,dims,dim1,dim2,dim3,dim4,dim5,dim6,start,count, &
                                   long_name,standard_name,grid_mapping,units,missing_value)
 
-        implicit none 
+        implicit none
 
         ! Arguments
         double precision :: dat(:,:,:,:)
@@ -2011,7 +2011,7 @@ contains
         integer, optional :: start(:), count(:),ncid
         character (len=*), optional :: dims(:), dim1, dim2, dim3, dim4, dim5, dim6
         character (len=*), optional :: long_name, standard_name, grid_mapping, units
-        double precision, allocatable :: dat1D(:) 
+        double precision, allocatable :: dat1D(:)
 
         allocate(dat1D(size(dat)))
         dat1D = pack(dble(dat),.TRUE.)    ! Pack here to avoid segmentation faults!
@@ -2029,7 +2029,7 @@ contains
     subroutine nc_write_double_5D(filename,name,dat,ncid,dims,dim1,dim2,dim3,dim4,dim5,dim6,start,count, &
                                   long_name,standard_name,grid_mapping,units,missing_value)
 
-        implicit none 
+        implicit none
 
         ! Arguments
         double precision :: dat(:,:,:,:,:)
@@ -2039,7 +2039,7 @@ contains
         integer, optional :: start(:), count(:),ncid
         character (len=*), optional :: dims(:), dim1, dim2, dim3, dim4, dim5, dim6
         character (len=*), optional :: long_name, standard_name, grid_mapping, units
-        double precision, allocatable :: dat1D(:) 
+        double precision, allocatable :: dat1D(:)
 
         allocate(dat1D(size(dat)))
         dat1D = pack(dble(dat),.TRUE.)    ! Pack here to avoid segmentation faults!
@@ -2057,7 +2057,7 @@ contains
     subroutine nc_write_double_6D(filename,name,dat,ncid,dims,dim1,dim2,dim3,dim4,dim5,dim6,start,count, &
                                   long_name,standard_name,grid_mapping,units,missing_value)
 
-        implicit none 
+        implicit none
 
         ! Arguments
         double precision :: dat(:,:,:,:,:,:)
@@ -2067,7 +2067,7 @@ contains
         integer, optional :: start(:), count(:),ncid
         character (len=*), optional :: dims(:), dim1, dim2, dim3, dim4, dim5, dim6
         character (len=*), optional :: long_name, standard_name, grid_mapping, units
-        double precision, allocatable :: dat1D(:) 
+        double precision, allocatable :: dat1D(:)
 
         allocate(dat1D(size(dat)))
         dat1D = pack(dble(dat),.TRUE.)    ! Pack here to avoid segmentation faults!
@@ -2084,14 +2084,14 @@ contains
 
 ! ================================
 !
-!      FLOATS 
+!      FLOATS
 !
 ! ================================
-    
+
     subroutine nc_write_float_pt(filename,name,dat,ncid,dims,dim1,dim2,dim3,dim4,dim5,dim6,start,count, &
                                   long_name,standard_name,grid_mapping,units,missing_value)
 
-        implicit none 
+        implicit none
 
         ! Arguments
         real(4) :: dat
@@ -2116,7 +2116,7 @@ contains
     subroutine nc_write_float_1D(filename,name,dat,ncid,dims,dim1,dim2,dim3,dim4,dim5,dim6,start,count, &
                                   long_name,standard_name,grid_mapping,units,missing_value)
 
-        implicit none 
+        implicit none
 
         ! Arguments
         real(4) :: dat(:)
@@ -2126,7 +2126,7 @@ contains
         integer, optional :: start(:), count(:),ncid
         character (len=*), optional :: dims(:), dim1, dim2, dim3, dim4, dim5, dim6
         character (len=*), optional :: long_name, standard_name, grid_mapping, units
-        double precision, allocatable :: dat1D(:) 
+        double precision, allocatable :: dat1D(:)
 
         allocate(dat1D(size(dat)))
         dat1D = pack(dble(dat),.TRUE.)    ! Pack here to avoid segmentation faults!
@@ -2144,7 +2144,7 @@ contains
     subroutine nc_write_float_2D(filename,name,dat,ncid,dims,dim1,dim2,dim3,dim4,dim5,dim6,start,count, &
                                   long_name,standard_name,grid_mapping,units,missing_value)
 
-        implicit none 
+        implicit none
 
         ! Arguments
         real(4) :: dat(:,:)
@@ -2154,7 +2154,7 @@ contains
         integer, optional :: start(:), count(:),ncid
         character (len=*), optional :: dims(:), dim1, dim2, dim3, dim4, dim5, dim6
         character (len=*), optional :: long_name, standard_name, grid_mapping, units
-        double precision, allocatable :: dat1D(:) 
+        double precision, allocatable :: dat1D(:)
 
         allocate(dat1D(size(dat)))
         dat1D = pack(dble(dat),.TRUE.)    ! Pack here to avoid segmentation faults!
@@ -2172,7 +2172,7 @@ contains
     subroutine nc_write_float_3D(filename,name,dat,dims,ncid,dim1,dim2,dim3,dim4,dim5,dim6,start,count, &
                                   long_name,standard_name,grid_mapping,units,missing_value)
 
-        implicit none 
+        implicit none
 
         ! Arguments
         real(4) :: dat(:,:,:)
@@ -2183,7 +2183,7 @@ contains
         character (len=*), optional :: dims(:), dim1, dim2, dim3, dim4, dim5, dim6
         character (len=*), optional :: long_name, standard_name, grid_mapping, units
 
-        double precision, allocatable :: dat1D(:) 
+        double precision, allocatable :: dat1D(:)
 
         allocate(dat1D(size(dat)))
         dat1D = pack(dble(dat),.TRUE.)    ! Pack here to avoid segmentation faults!
@@ -2201,7 +2201,7 @@ contains
     subroutine nc_write_float_4D(filename,name,dat,ncid,dims,dim1,dim2,dim3,dim4,dim5,dim6,start,count, &
                                   long_name,standard_name,grid_mapping,units,missing_value)
 
-        implicit none 
+        implicit none
 
         ! Arguments
         real(4) :: dat(:,:,:,:)
@@ -2211,7 +2211,7 @@ contains
         integer, optional :: start(:), count(:),ncid
         character (len=*), optional :: dims(:), dim1, dim2, dim3, dim4, dim5, dim6
         character (len=*), optional :: long_name, standard_name, grid_mapping, units
-        double precision, allocatable :: dat1D(:) 
+        double precision, allocatable :: dat1D(:)
 
         allocate(dat1D(size(dat)))
         dat1D = pack(dble(dat),.TRUE.)    ! Pack here to avoid segmentation faults!
@@ -2229,7 +2229,7 @@ contains
     subroutine nc_write_float_5D(filename,name,dat,ncid,dims,dim1,dim2,dim3,dim4,dim5,dim6,start,count, &
                                   long_name,standard_name,grid_mapping,units,missing_value)
 
-        implicit none 
+        implicit none
 
         ! Arguments
         real(4) :: dat(:,:,:,:,:)
@@ -2239,7 +2239,7 @@ contains
         integer, optional :: start(:), count(:),ncid
         character (len=*), optional :: dims(:), dim1, dim2, dim3, dim4, dim5, dim6
         character (len=*), optional :: long_name, standard_name, grid_mapping, units
-        double precision, allocatable :: dat1D(:) 
+        double precision, allocatable :: dat1D(:)
 
         allocate(dat1D(size(dat)))
         dat1D = pack(dble(dat),.TRUE.)    ! Pack here to avoid segmentation faults!
@@ -2257,7 +2257,7 @@ contains
     subroutine nc_write_float_6D(filename,name,dat,ncid,dims,dim1,dim2,dim3,dim4,dim5,dim6,start,count, &
                                   long_name,standard_name,grid_mapping,units,missing_value)
 
-        implicit none 
+        implicit none
 
         ! Arguments
         real(4) :: dat(:,:,:,:,:,:)
@@ -2267,7 +2267,7 @@ contains
         integer, optional :: start(:), count(:),ncid
         character (len=*), optional :: dims(:), dim1, dim2, dim3, dim4, dim5, dim6
         character (len=*), optional :: long_name, standard_name, grid_mapping, units
-        double precision, allocatable :: dat1D(:) 
+        double precision, allocatable :: dat1D(:)
 
         allocate(dat1D(size(dat)))
         dat1D = pack(dble(dat),.TRUE.)    ! Pack here to avoid segmentation faults!
@@ -2291,7 +2291,7 @@ contains
     subroutine nc_write_logical_pt(filename,name,dat,ncid,dims,dim1,dim2,dim3,dim4,dim5,dim6,start,count, &
                                    long_name,standard_name,grid_mapping,units)
 
-        implicit none 
+        implicit none
 
         ! Arguments
         logical :: dat
@@ -2301,9 +2301,9 @@ contains
         character (len=*), optional :: dims(:), dim1, dim2, dim3, dim4, dim5, dim6
         character (len=*), optional :: long_name, standard_name, grid_mapping, units
         integer :: dati
-         
+
         dati = 0
-        if (dat) dati = 1  
+        if (dat) dati = 1
 
         ! Finally call the internal writing routine
         call nc4_write_internal(filename,name,dble([dati]),"NF90_INT",shape([dat]), &
@@ -2317,7 +2317,7 @@ contains
     subroutine nc_write_logical_1D(filename,name,dat,ncid,dims,dim1,dim2,dim3,dim4,dim5,dim6,start,count, &
                                    long_name,standard_name,grid_mapping,units)
 
-        implicit none 
+        implicit none
 
         ! Arguments
         logical :: dat(:)
@@ -2326,12 +2326,12 @@ contains
         integer, optional :: start(:), count(:),ncid
         character (len=*), optional :: dims(:), dim1, dim2, dim3, dim4, dim5, dim6
         character (len=*), optional :: long_name, standard_name, grid_mapping, units
-        double precision, allocatable :: dat1D(:) 
-        integer, allocatable :: dati(:) 
-        
+        double precision, allocatable :: dat1D(:)
+        integer, allocatable :: dati(:)
+
         allocate(dati(size(dat)),dat1D(size(dat)))
         dati = 0
-        where (dat) dati = 1 
+        where (dat) dati = 1
         dat1D = pack(dble(dati),.TRUE.)    ! Pack here to avoid segmentation faults!
 
         ! Finally call the internal writing routine
@@ -2346,7 +2346,7 @@ contains
     subroutine nc_write_logical_2D(filename,name,dat,ncid,dims,dim1,dim2,dim3,dim4,dim5,dim6,start,count, &
                                    long_name,standard_name,grid_mapping,units)
 
-        implicit none 
+        implicit none
 
         ! Arguments
         logical :: dat(:,:)
@@ -2355,12 +2355,12 @@ contains
         integer, optional :: start(:), count(:),ncid
         character (len=*), optional :: dims(:), dim1, dim2, dim3, dim4, dim5, dim6
         character (len=*), optional :: long_name, standard_name, grid_mapping, units
-        double precision, allocatable :: dat1D(:) 
+        double precision, allocatable :: dat1D(:)
         integer, allocatable :: dati(:,:)
 
         allocate(dati(size(dat,1),size(dat,2)),dat1D(size(dat)))
         dati = 0
-        where (dat) dati = 1 
+        where (dat) dati = 1
         dat1D = pack(dble(dati),.TRUE.)    ! Pack here to avoid segmentation faults!
 
         ! Finally call the internal writing routine
@@ -2375,7 +2375,7 @@ contains
     subroutine nc_write_logical_3D(filename,name,dat,ncid,dims,dim1,dim2,dim3,dim4,dim5,dim6,start,count, &
                                    long_name,standard_name,grid_mapping,units)
 
-        implicit none 
+        implicit none
 
         ! Arguments
         logical :: dat(:,:,:)
@@ -2384,12 +2384,12 @@ contains
         integer, optional :: start(:), count(:),ncid
         character (len=*), optional :: dims(:), dim1, dim2, dim3, dim4, dim5, dim6
         character (len=*), optional :: long_name, standard_name, grid_mapping, units
-        double precision, allocatable :: dat1D(:) 
+        double precision, allocatable :: dat1D(:)
         integer, allocatable :: dati(:,:,:)
 
         allocate(dati(size(dat,1),size(dat,2),size(dat,3)),dat1D(size(dat)))
         dati = 0
-        where (dat) dati = 1 
+        where (dat) dati = 1
         dat1D = pack(dble(dati),.TRUE.)    ! Pack here to avoid segmentation faults!
 
         ! Finally call the internal writing routine
@@ -2404,7 +2404,7 @@ contains
     subroutine nc_write_logical_4D(filename,name,dat,ncid,dims,dim1,dim2,dim3,dim4,dim5,dim6,start,count, &
                                    long_name,standard_name,grid_mapping,units)
 
-        implicit none 
+        implicit none
 
         ! Arguments
         logical :: dat(:,:,:,:)
@@ -2413,12 +2413,12 @@ contains
         integer, optional :: start(:), count(:),ncid
         character (len=*), optional :: dims(:), dim1, dim2, dim3, dim4, dim5, dim6
         character (len=*), optional :: long_name, standard_name, grid_mapping, units
-        double precision, allocatable :: dat1D(:) 
+        double precision, allocatable :: dat1D(:)
         integer, allocatable :: dati(:,:,:,:)
 
         allocate(dati(size(dat,1),size(dat,2),size(dat,3),size(dat,4)),dat1D(size(dat)))
         dati = 0
-        where (dat) dati = 1 
+        where (dat) dati = 1
         dat1D = pack(dble(dati),.TRUE.)    ! Pack here to avoid segmentation faults!
 
         ! Finally call the internal writing routine
@@ -2433,7 +2433,7 @@ contains
     subroutine nc_write_logical_5D(filename,name,dat,ncid,dims,dim1,dim2,dim3,dim4,dim5,dim6,start,count, &
                                   long_name,standard_name,grid_mapping,units)
 
-        implicit none 
+        implicit none
 
         ! Arguments
         logical :: dat(:,:,:,:,:)
@@ -2442,13 +2442,13 @@ contains
         integer, optional :: start(:), count(:),ncid
         character (len=*), optional :: dims(:), dim1, dim2, dim3, dim4, dim5, dim6
         character (len=*), optional :: long_name, standard_name, grid_mapping, units
-        double precision, allocatable :: dat1D(:) 
+        double precision, allocatable :: dat1D(:)
         integer, allocatable :: dati(:,:,:,:,:)
 
         allocate(dati(size(dat,1),size(dat,2),size(dat,3),size(dat,4),size(dat,5)))
         allocate(dat1D(size(dat)))
         dati = 0
-        where (dat) dati = 1 
+        where (dat) dati = 1
         dat1D = pack(dble(dati),.TRUE.)    ! Pack here to avoid segmentation faults!
 
         ! Finally call the internal writing routine
@@ -2463,7 +2463,7 @@ contains
     subroutine nc_write_logical_6D(filename,name,dat,ncid,dims,dim1,dim2,dim3,dim4,dim5,dim6,start,count, &
                                    long_name,standard_name,grid_mapping,units)
 
-        implicit none 
+        implicit none
 
         ! Arguments
         logical :: dat(:,:,:,:,:,:)
@@ -2472,13 +2472,13 @@ contains
         integer, optional :: start(:), count(:),ncid
         character (len=*), optional :: dims(:), dim1, dim2, dim3, dim4, dim5, dim6
         character (len=*), optional :: long_name, standard_name, grid_mapping, units
-        double precision, allocatable :: dat1D(:) 
+        double precision, allocatable :: dat1D(:)
         integer, allocatable :: dati(:,:,:,:,:,:)
 
         allocate(dati(size(dat,1),size(dat,2),size(dat,3),size(dat,4),size(dat,5),size(dat,6)))
         allocate(dat1D(size(dat)))
         dati = 0
-        where (dat) dati = 1 
+        where (dat) dati = 1
         dat1D = pack(dble(dati),.TRUE.)    ! Pack here to avoid segmentation faults!
 
         ! Finally call the internal writing routine
@@ -2500,7 +2500,7 @@ contains
 
 ! ================================
 !
-!      INTS 
+!      INTS
 !
 ! ================================
     !> Read an integer value (one point) from a NetCDF file.
@@ -2511,19 +2511,19 @@ contains
     !! @param count vector of values specifying how many values to read in each dimension
     subroutine nc_read_int_pt(filename,name,dat,start,count,missing_value, ncid)
 
-        implicit none 
+        implicit none
 
         double precision, dimension(:), allocatable :: dat1D
 
         ! Arguments
         character (len=*) :: filename, name
         integer, optional :: start(:), count(:), ncid
-        
+
         !! Arguments related to data size and type
         integer :: dat
         character(len=NC_STRLEN), parameter :: xtype    = "NF90_INT"
 
-        integer, optional :: missing_value 
+        integer, optional :: missing_value
 
         ! Allocate dat1D and store input data to faciliate calling internal write subroutine
         if (allocated(dat1D)) deallocate(dat1D)
@@ -2542,19 +2542,19 @@ contains
 
     subroutine nc_read_int_1D(filename,name,dat,start,count,missing_value, ncid)
 
-        implicit none 
+        implicit none
 
         double precision, dimension(:), allocatable :: dat1D
 
         ! Arguments
         character (len=*) :: filename, name
         integer, optional :: start(:), count(:), ncid
-        
+
         !! Arguments related to data size and type
         integer :: dat(:)
         character(len=NC_STRLEN), parameter :: xtype    = "NF90_INT"
 
-        integer, optional :: missing_value 
+        integer, optional :: missing_value
 
         ! Allocate dat1D and store input data to faciliate calling internal write subroutine
         if (allocated(dat1D)) deallocate(dat1D)
@@ -2573,19 +2573,19 @@ contains
 
     subroutine nc_read_int_2D(filename,name,dat,start,count,missing_value, ncid)
 
-        implicit none 
+        implicit none
 
         double precision, dimension(:), allocatable :: dat1D
 
         ! Arguments
         character (len=*) :: filename, name
         integer, optional :: start(:), count(:), ncid
-        
+
         !! Arguments related to data size and type
         integer :: dat(:,:)
         character(len=NC_STRLEN), parameter :: xtype    = "NF90_INT"
 
-        integer, optional :: missing_value 
+        integer, optional :: missing_value
 
         ! Allocate dat4D and store input data to faciliate calling internal write subroutine
         if (allocated(dat1D)) deallocate(dat1D)
@@ -2604,19 +2604,19 @@ contains
 
     subroutine nc_read_int_3D(filename,name,dat,start,count,missing_value, ncid)
 
-        implicit none 
+        implicit none
 
         double precision, dimension(:), allocatable :: dat1D
 
         ! Arguments
         character (len=*) :: filename, name
         integer, optional :: start(:), count(:), ncid
-        
+
         !! Arguments related to data size and type
         integer :: dat(:,:,:)
         character(len=NC_STRLEN), parameter :: xtype    = "NF90_INT"
 
-        integer, optional :: missing_value 
+        integer, optional :: missing_value
 
         ! Allocate dat1D and store input data to faciliate calling internal write subroutine
         if (allocated(dat1D)) deallocate(dat1D)
@@ -2635,19 +2635,19 @@ contains
 
     subroutine nc_read_int_4D(filename,name,dat,start,count,missing_value, ncid)
 
-        implicit none 
+        implicit none
 
         double precision, dimension(:), allocatable :: dat1D
 
         ! Arguments
         character (len=*) :: filename, name
         integer, optional :: start(:), count(:), ncid
-        
+
         !! Arguments related to data size and type
         integer :: dat(:,:,:,:)
         character(len=NC_STRLEN), parameter :: xtype    = "NF90_INT"
 
-        integer, optional :: missing_value 
+        integer, optional :: missing_value
 
         ! Allocate dat1D and store input data to faciliate calling internal write subroutine
         if (allocated(dat1D)) deallocate(dat1D)
@@ -2666,19 +2666,19 @@ contains
 
     subroutine nc_read_int_5D(filename,name,dat,start,count,missing_value, ncid)
 
-        implicit none 
+        implicit none
 
         double precision, dimension(:), allocatable :: dat1D
 
         ! Arguments
         character (len=*) :: filename, name
         integer, optional :: start(:), count(:), ncid
-        
+
         !! Arguments related to data size and type
         integer :: dat(:,:,:,:,:)
         character(len=NC_STRLEN), parameter :: xtype    = "NF90_INT"
 
-        integer, optional :: missing_value 
+        integer, optional :: missing_value
 
         ! Allocate dat1D and store input data to facilitate calling internal write subroutine
         if (allocated(dat1D)) deallocate(dat1D)
@@ -2697,19 +2697,19 @@ contains
 
     subroutine nc_read_int_6D(filename,name,dat,start,count,missing_value, ncid)
 
-        implicit none 
+        implicit none
 
         double precision, dimension(:), allocatable :: dat1D
 
         ! Arguments
         character (len=*) :: filename, name
         integer, optional :: start(:), count(:), ncid
-        
+
         !! Arguments related to data size and type
         integer :: dat(:,:,:,:,:,:)
         character(len=NC_STRLEN), parameter :: xtype    = "NF90_INT"
 
-        integer, optional :: missing_value 
+        integer, optional :: missing_value
 
         ! Allocate dat1D and store input data to facilitate calling internal write subroutine
         if (allocated(dat1D)) deallocate(dat1D)
@@ -2728,25 +2728,25 @@ contains
 
 ! ================================
 !
-!      DOUBLES 
+!      DOUBLES
 !
 ! ================================
-    
+
     subroutine nc_read_double_pt(filename,name,dat,start,count,missing_value, ncid)
 
-        implicit none 
+        implicit none
 
         double precision, dimension(:), allocatable :: dat1D
 
         ! Arguments
         character (len=*) :: filename, name
         integer, optional :: start(:), count(:), ncid
-        
+
         !! Arguments related to data size and type
         double precision :: dat
         character(len=NC_STRLEN), parameter :: xtype    = "NF90_DOUBLE"
 
-        double precision, optional :: missing_value 
+        double precision, optional :: missing_value
 
         ! Allocate dat1D and store input data to facilitate calling internal write subroutine
         if (allocated(dat1D)) deallocate(dat1D)
@@ -2765,19 +2765,19 @@ contains
 
     subroutine nc_read_double_1D(filename,name,dat,start,count,missing_value, ncid)
 
-        implicit none 
+        implicit none
 
         double precision, dimension(:), allocatable :: dat1D
 
         ! Arguments
         character (len=*) :: filename, name
         integer, optional :: start(:), count(:), ncid
-        
+
         !! Arguments related to data size and type
         double precision :: dat(:)
         character(len=NC_STRLEN), parameter :: xtype    = "NF90_DOUBLE"
 
-        double precision, optional :: missing_value 
+        double precision, optional :: missing_value
 
         ! Allocate dat1D and store input data to facilitate calling internal write subroutine
         if (allocated(dat1D)) deallocate(dat1D)
@@ -2796,19 +2796,19 @@ contains
 
     subroutine nc_read_double_2D(filename,name,dat,start,count,missing_value, ncid)
 
-        implicit none 
+        implicit none
 
         double precision, dimension(:), allocatable :: dat1D
 
         ! Arguments
         character (len=*) :: filename, name
         integer, optional :: start(:), count(:), ncid
-        
+
         !! Arguments related to data size and type
         double precision :: dat(:,:)
         character(len=NC_STRLEN), parameter :: xtype    = "NF90_DOUBLE"
 
-        double precision, optional :: missing_value 
+        double precision, optional :: missing_value
 
         ! Allocate dat1D and store input data to facilitate calling internal write subroutine
         if (allocated(dat1D)) deallocate(dat1D)
@@ -2827,19 +2827,19 @@ contains
 
     subroutine nc_read_double_3D(filename,name,dat,start,count,missing_value, ncid)
 
-        implicit none 
+        implicit none
 
         double precision, dimension(:), allocatable :: dat1D
 
         ! Arguments
         character (len=*) :: filename, name
         integer, optional :: start(:), count(:), ncid
-        
+
         !! Arguments related to data size and type
         double precision :: dat(:,:,:)
         character(len=NC_STRLEN), parameter :: xtype    = "NF90_DOUBLE"
 
-        double precision, optional :: missing_value 
+        double precision, optional :: missing_value
 
         ! Allocate dat1D and store input data to facilitate calling internal write subroutine
         if (allocated(dat1D)) deallocate(dat1D)
@@ -2858,19 +2858,19 @@ contains
 
     subroutine nc_read_double_4D(filename,name,dat,start,count,missing_value, ncid)
 
-        implicit none 
+        implicit none
 
         double precision, dimension(:), allocatable :: dat1D
 
         ! Arguments
         character (len=*) :: filename, name
         integer, optional :: start(:), count(:), ncid
-        
+
         !! Arguments related to data size and type
         double precision :: dat(:,:,:,:)
         character(len=NC_STRLEN), parameter :: xtype    = "NF90_DOUBLE"
 
-        double precision, optional :: missing_value 
+        double precision, optional :: missing_value
 
         ! Allocate dat1D and store input data to facilitate calling internal write subroutine
         if (allocated(dat1D)) deallocate(dat1D)
@@ -2889,19 +2889,19 @@ contains
 
     subroutine nc_read_double_5D(filename,name,dat,start,count,missing_value, ncid)
 
-        implicit none 
+        implicit none
 
         double precision, dimension(:), allocatable :: dat1D
 
         ! Arguments
         character (len=*) :: filename, name
         integer, optional :: start(:), count(:), ncid
-        
+
         !! Arguments related to data size and type
         double precision :: dat(:,:,:,:,:)
         character(len=NC_STRLEN), parameter :: xtype    = "NF90_DOUBLE"
 
-        double precision, optional :: missing_value 
+        double precision, optional :: missing_value
 
         ! Allocate dat1D and store input data to facilitate calling internal write subroutine
         if (allocated(dat1D)) deallocate(dat1D)
@@ -2920,19 +2920,19 @@ contains
 
     subroutine nc_read_double_6D(filename,name,dat,start,count,missing_value, ncid)
 
-        implicit none 
+        implicit none
 
         double precision, dimension(:), allocatable :: dat1D
 
         ! Arguments
         character (len=*) :: filename, name
         integer, optional :: start(:), count(:), ncid
-        
+
         !! Arguments related to data size and type
         double precision :: dat(:,:,:,:,:,:)
         character(len=NC_STRLEN), parameter :: xtype    = "NF90_DOUBLE"
 
-        double precision, optional :: missing_value 
+        double precision, optional :: missing_value
 
         ! Allocate dat1D and store input data to facilitate calling internal write subroutine
         if (allocated(dat1D)) deallocate(dat1D)
@@ -2954,22 +2954,22 @@ contains
 !      FLOATS
 !
 ! ================================
-    
+
     subroutine nc_read_float_pt(filename,name,dat,start,count,missing_value, ncid)
 
-        implicit none 
+        implicit none
 
         double precision, dimension(:), allocatable :: dat1D
 
         ! Arguments
         character (len=*) :: filename, name
         integer, optional :: start(:), count(:), ncid
-        
+
         !! Arguments related to data size and type
         real(4) :: dat
         character(len=NC_STRLEN), parameter :: xtype    = "NF90_FLOAT"
 
-        real(4), optional :: missing_value 
+        real(4), optional :: missing_value
 
         ! Allocate dat1D and store input data to facilitate calling internal write subroutine
         if (allocated(dat1D)) deallocate(dat1D)
@@ -2988,19 +2988,19 @@ contains
 
     subroutine nc_read_float_1D(filename,name,dat,start,count,missing_value, ncid)
 
-        implicit none 
+        implicit none
 
         double precision, dimension(:), allocatable :: dat1D
 
         ! Arguments
         character (len=*) :: filename, name
         integer, optional :: start(:), count(:), ncid
-        
+
         !! Arguments related to data size and type
         real(4) :: dat(:)
         character(len=NC_STRLEN), parameter :: xtype    = "NF90_FLOAT"
 
-        real(4), optional :: missing_value 
+        real(4), optional :: missing_value
 
         ! Allocate dat1D and store input data to facilitate calling internal write subroutine
         if (allocated(dat1D)) deallocate(dat1D)
@@ -3019,19 +3019,19 @@ contains
 
     subroutine nc_read_float_2D(filename,name,dat,start,count,missing_value, ncid)
 
-        implicit none 
+        implicit none
 
         double precision, dimension(:), allocatable :: dat1D
 
         ! Arguments
         character (len=*) :: filename, name
         integer, optional :: start(:), count(:), ncid
-        
+
         !! Arguments related to data size and type
         real(4) :: dat(:,:)
         character(len=NC_STRLEN), parameter :: xtype    = "NF90_FLOAT"
 
-        real(4), optional :: missing_value 
+        real(4), optional :: missing_value
 
         ! Allocate dat1D and store input data to facilitate calling internal write subroutine
         if (allocated(dat1D)) deallocate(dat1D)
@@ -3050,19 +3050,19 @@ contains
 
     subroutine nc_read_float_3D(filename,name,dat,start,count,missing_value, ncid)
 
-        implicit none 
+        implicit none
 
         double precision, dimension(:), allocatable :: dat1D
 
         ! Arguments
         character (len=*) :: filename, name
         integer, optional :: start(:), count(:), ncid
-        
+
         !! Arguments related to data size and type
         real(4) :: dat(:,:,:)
         character(len=NC_STRLEN), parameter :: xtype    = "NF90_FLOAT"
 
-        real(4), optional :: missing_value 
+        real(4), optional :: missing_value
 
         ! Allocate dat1D and store input data to facilitate calling internal write subroutine
         if (allocated(dat1D)) deallocate(dat1D)
@@ -3081,19 +3081,19 @@ contains
 
     subroutine nc_read_float_4D(filename,name,dat,start,count,missing_value, ncid)
 
-        implicit none 
+        implicit none
 
         double precision, dimension(:), allocatable :: dat1D
 
         ! Arguments
         character (len=*) :: filename, name
         integer, optional :: start(:), count(:), ncid
-        
+
         !! Arguments related to data size and type
         real(4) :: dat(:,:,:,:)
         character(len=NC_STRLEN), parameter :: xtype    = "NF90_FLOAT"
 
-        real(4), optional :: missing_value 
+        real(4), optional :: missing_value
 
         ! Allocate dat1D and store input data to facilitate calling internal write subroutine
         if (allocated(dat1D)) deallocate(dat1D)
@@ -3112,19 +3112,19 @@ contains
 
     subroutine nc_read_float_5D(filename,name,dat,start,count,missing_value, ncid)
 
-        implicit none 
+        implicit none
 
         double precision, dimension(:), allocatable :: dat1D
 
         ! Arguments
         character (len=*) :: filename, name
         integer, optional :: start(:), count(:), ncid
-        
+
         !! Arguments related to data size and type
         real(4) :: dat(:,:,:,:,:)
         character(len=NC_STRLEN), parameter :: xtype    = "NF90_FLOAT"
 
-        real(4), optional :: missing_value 
+        real(4), optional :: missing_value
 
         ! Allocate dat1D and store input data to facilitate calling internal write subroutine
         if (allocated(dat1D)) deallocate(dat1D)
@@ -3143,19 +3143,19 @@ contains
 
     subroutine nc_read_float_6D(filename,name,dat,start,count,missing_value, ncid)
 
-        implicit none 
+        implicit none
 
         double precision, dimension(:), allocatable :: dat1D
 
         ! Arguments
         character (len=*) :: filename, name
         integer, optional :: start(:), count(:), ncid
-        
+
         !! Arguments related to data size and type
         real(4) :: dat(:,:,:,:,:,:)
         character(len=NC_STRLEN), parameter :: xtype    = "NF90_FLOAT"
 
-        real(4), optional :: missing_value 
+        real(4), optional :: missing_value
 
         ! Allocate dat1D and store input data to facilitate calling internal write subroutine
         if (allocated(dat1D)) deallocate(dat1D)
@@ -3174,20 +3174,20 @@ contains
 
 ! ================================
 !
-!      LOGICALS 
+!      LOGICALS
 !
 ! ================================
 
     subroutine nc_read_logical_pt(filename,name,dat,start,count,ncid)
 
-        implicit none 
+        implicit none
 
         double precision, dimension(:), allocatable :: dat1D
 
         ! Arguments
         character (len=*) :: filename, name
         integer, optional :: start(:), count(:),ncid
-        
+
         !! Arguments related to data size and type
         logical :: dat
         character(len=NC_STRLEN), parameter :: xtype    = "NF90_INT"
@@ -3209,14 +3209,14 @@ contains
 
     subroutine nc_read_logical_1D(filename,name,dat,start,count,ncid)
 
-        implicit none 
+        implicit none
 
         double precision, dimension(:), allocatable :: dat1D
 
         ! Arguments
         character (len=*) :: filename, name
         integer, optional :: start(:), count(:),ncid
-        
+
         !! Arguments related to data size and type
         logical :: dat(:)
         character(len=NC_STRLEN), parameter :: xtype    = "NF90_INT"
@@ -3238,14 +3238,14 @@ contains
 
     subroutine nc_read_logical_2D(filename,name,dat,start,count,ncid)
 
-        implicit none 
+        implicit none
 
         double precision, dimension(:), allocatable :: dat1D
 
         ! Arguments
         character (len=*) :: filename, name
         integer, optional :: start(:), count(:),ncid
-        
+
         !! Arguments related to data size and type
         logical :: dat(:,:)
         character(len=NC_STRLEN), parameter :: xtype    = "NF90_INT"
@@ -3267,14 +3267,14 @@ contains
 
     subroutine nc_read_logical_3D(filename,name,dat,start,count,ncid)
 
-        implicit none 
+        implicit none
 
         double precision, dimension(:), allocatable :: dat1D
 
         ! Arguments
         character (len=*) :: filename, name
         integer, optional :: start(:), count(:),ncid
-        
+
         !! Arguments related to data size and type
         logical :: dat(:,:,:)
         character(len=NC_STRLEN), parameter :: xtype    = "NF90_INT"
@@ -3296,14 +3296,14 @@ contains
 
     subroutine nc_read_logical_4D(filename,name,dat,start,count,ncid)
 
-        implicit none 
+        implicit none
 
         double precision, dimension(:), allocatable :: dat1D
 
         ! Arguments
         character (len=*) :: filename, name
         integer, optional :: start(:), count(:),ncid
-        
+
         !! Arguments related to data size and type
         logical :: dat(:,:,:,:)
         character(len=NC_STRLEN), parameter :: xtype    = "NF90_INT"
@@ -3325,14 +3325,14 @@ contains
 
     subroutine nc_read_logical_5D(filename,name,dat,start,count,ncid)
 
-        implicit none 
+        implicit none
 
         double precision, dimension(:), allocatable :: dat1D
 
         ! Arguments
         character (len=*) :: filename, name
         integer, optional :: start(:), count(:),ncid
-        
+
         !! Arguments related to data size and type
         logical :: dat(:,:,:,:,:)
         character(len=NC_STRLEN), parameter :: xtype    = "NF90_INT"
@@ -3354,14 +3354,14 @@ contains
 
     subroutine nc_read_logical_6D(filename,name,dat,start,count,ncid)
 
-        implicit none 
+        implicit none
 
         double precision, dimension(:), allocatable :: dat1D
 
         ! Arguments
         character (len=*) :: filename, name
         integer, optional :: start(:), count(:),ncid
-        
+
         !! Arguments related to data size and type
         logical :: dat(:,:,:,:,:,:)
         character(len=NC_STRLEN), parameter :: xtype    = "NF90_INT"
@@ -3383,20 +3383,20 @@ contains
 
 ! ================================
 !
-!      CHARACTERS 
+!      CHARACTERS
 !
 ! ================================
 
     subroutine nc_write_char_1D(filename,name,dat,ncid)
 
-        implicit none 
+        implicit none
 
         character(len=NC_STRLEN_MAX) :: string
 
         ! Arguments
         character(len=*) :: dat(:)
         character (len=*) :: filename, name
-        integer :: i 
+        integer :: i
         integer, intent(in), optional :: ncid
 
         ! Convert the character array into a long string
@@ -3414,7 +3414,7 @@ contains
 
     subroutine nc_write_char_2D(filename,name,dat, ncid)
 
-        implicit none 
+        implicit none
 
         character(len=NC_STRLEN_MAX) :: string
 
@@ -3433,7 +3433,7 @@ contains
 
     subroutine nc_write_char_3D(filename,name,dat, ncid)
 
-        implicit none 
+        implicit none
 
         character(len=NC_STRLEN_MAX) :: string
 
@@ -3452,7 +3452,7 @@ contains
 
     subroutine nc_write_char_4D(filename,name,dat, ncid)
 
-        implicit none 
+        implicit none
 
         character(len=NC_STRLEN_MAX) :: string
 
@@ -3471,18 +3471,18 @@ contains
 
     subroutine nc_read_char_1D(filename,name,dat,sep,ncid)
 
-        implicit none 
+        implicit none
 
         character(len=NC_STRLEN_MAX) :: string
 
         ! Arguments
         character(len=*) :: dat(:)
-        character(len=*), optional :: sep 
+        character(len=*), optional :: sep
         character (len=*) :: filename, name
-        integer :: i, j, nsep 
+        integer :: i, j, nsep
         integer, intent(in), optional :: ncid
 
-        character(len=10) :: separator 
+        character(len=10) :: separator
 
         ! Determine the separator used to parse the elements of the
         ! array from the string saved in the netcdf file
@@ -3508,12 +3508,12 @@ contains
 
     subroutine nc_write_internal_char(filename,name,string, ncid)
 
-        implicit none 
+        implicit none
 
         character (len=*), intent(in) :: string
         character (len=*), intent(in) :: filename, name
         integer, intent(in), optional :: ncid
-        character (len=256) :: dimname 
+        character (len=256) :: dimname
 
         type(ncvar) :: v
 
@@ -3524,7 +3524,7 @@ contains
         call nc_v_init(v,trim(name),xtype="NF90_CHAR")
 
         dimname = trim(v%name)//"_len"
-        str_len = len_trim(string) 
+        str_len = len_trim(string)
 
         ! Open the file
         call nc_check_open(filename, ncid, nf90_write, nc_id)
@@ -3534,7 +3534,7 @@ contains
         call nc_check( nf90_def_dim(nc_id, trim(dimname), str_len, dimid) )
         call nc_check( nf90_def_var(nc_id, trim(v%name), NF90_CHAR, (/ dimid /), v%varid) )
         call nc_check( nf90_enddef(nc_id) )
-        
+
         ! Write the data to the netcdf file
         ! (NF90 converts dat to proper type (int, real, dble)
         call nc_check( nf90_put_var(nc_id, v%varid, trim(string) ) )
@@ -3544,14 +3544,14 @@ contains
         if (.not. present(ncid)) call nc_check( nf90_close(nc_id) )
 
         !write(*,"(a,a,a14)") "ncio:: nc_write_char:: ",trim(filename)//" : ",trim(v%name)
-        
-        return 
+
+        return
 
     end subroutine nc_write_internal_char
 
     subroutine nc_read_internal_char(filename,name,string, ncid)
 
-        implicit none 
+        implicit none
 
         character (len=*) :: string
         character (len=*) :: filename, name
@@ -3567,7 +3567,7 @@ contains
 
         ! Open the file if necessary
         call nc_check_open(filename, ncid, nf90_write, nc_id)
-        call nc_get_att(nc_id,v) 
+        call nc_get_att(nc_id,v)
 
         ! Read the string from the netcdf file
         call nc_check( nf90_get_var(nc_id, v%varid, string(1:v%dlen(1))) )
@@ -3580,17 +3580,17 @@ contains
         if (.not. present(ncid)) call nc_check( nf90_close(nc_id) )
 
         !write(*,"(a,a,a14)") "ncio:: nc_read_char:: ",trim(filename)//" : ",trim(v%name)
-        
-        return 
+
+        return
 
     end subroutine nc_read_internal_char
 
     function str_to_num(str)
-        implicit none 
-        character(len=*), intent(IN) :: str 
-        character(len=100) :: tmpstr 
+        implicit none
+        character(len=*), intent(IN) :: str
+        character(len=100) :: tmpstr
         integer :: stat, n
-        double precision :: str_to_num, x 
+        double precision :: str_to_num, x
 
         tmpstr = trim(adjustl(str))
         n      = len_trim(tmpstr)
@@ -3598,20 +3598,20 @@ contains
         read(tmpstr(1:n),*,IOSTAT=stat) x
 
         str_to_num = 0
-        if (stat .eq. 0) then 
-            str_to_num = x 
+        if (stat .eq. 0) then
+            str_to_num = x
         else
             n = len_trim(tmpstr)-1
             READ(tmpstr(1:n),*,IOSTAT=stat) x
-            if (stat .ne. 0) then 
+            if (stat .ne. 0) then
                 write(*,*) "ncio::str_to_num:: ","Error converting string to number!"
                 write(*,*) "|",trim(tmpstr),"|",n,stat,x
             else
-                str_to_num = x 
-            end if 
-        end if 
+                str_to_num = x
+            end if
+        end if
 
-        return 
-    end function str_to_num 
+        return
+    end function str_to_num
 
 end module ncio

--- a/ncio.f90
+++ b/ncio.f90
@@ -408,6 +408,7 @@ contains
             if (.not. ndims .eq. size(size_in)) then
                 write(*,"(a)") "nc_read:: ","Warning: "// &
                 "Variable dimensions in the file do not match those being read in."
+                write(*,"('  ndim = ', i2, ', size(size_in) = ', i2)") ndims, size(size_in)
                 write(*,*) trim(filename)//": ",trim(name)
             end if
             allocate(v%count(ndims))


### PR DESCRIPTION
I just triggered the `Variable dimensions in the file do not match those being read in.` error message and thought, a little more info would be nice, so I added 
`write(*,"('  ndim = ', i2, ', size(size_in) = ', i2)") ndims, size(size_in)`
below
