### PR TITLE
Improved treatment of _FillValue and missing_value attributes in write functions

### DIFF
--- a/ncio.f90
+++ b/ncio.f90
@@ -543,10 +543,10 @@ contains
         v%add_offset    = 0.d0
         v%scale_factor  = 1.d0
         v%actual_range  = (/ 0.d0, 0.d0 /)
-        v%missing_set   = .TRUE.
+        v%missing_set   = .FALSE.
         v%missing_value = -9999d0
         v%FillValue     = v%missing_value
-        v%FillValue_set = .TRUE.
+        v%FillValue_set = .FALSE.
 
         v%xtype = "NF90_DOUBLE"
         v%coord = .FALSE.

--- a/ncio.f90
+++ b/ncio.f90
@@ -183,12 +183,15 @@ contains
         if (present(missing_value_int)) then
             v%missing_set = .TRUE.
             v%missing_value = dble(missing_value_int)
+            v%FillValue = v%missing_value
         else if (present(missing_value_float)) then
             v%missing_set = .TRUE.
             v%missing_value = dble(missing_value_float)
+            v%FillValue = v%missing_value
         else if (present(missing_value_double)) then
             v%missing_set = .TRUE.
             v%missing_value = missing_value_double
+            v%FillValue = v%missing_value
         end if
 
         ! Open the file in write mode from filename or ncid

--- a/ncio.f90
+++ b/ncio.f90
@@ -182,14 +182,17 @@ contains
 
         if (present(missing_value_int)) then
             v%missing_set = .TRUE.
+            v%FillValue_set = .TRUE.
             v%missing_value = dble(missing_value_int)
             v%FillValue = v%missing_value
         else if (present(missing_value_float)) then
             v%missing_set = .TRUE.
+            v%FillValue_set = .TRUE.
             v%missing_value = dble(missing_value_float)
             v%FillValue = v%missing_value
         else if (present(missing_value_double)) then
             v%missing_set = .TRUE.
+            v%FillValue_set = .TRUE.
             v%missing_value = missing_value_double
             v%FillValue = v%missing_value
         end if


### PR DESCRIPTION
There are two minor problems with the way the _FillValue and missing value attributes are currently set:

1. The _FillValue attribute is always set to -9999d0
2. The _FillValue and missing_value attributes are set to -9999d0, even if ``missing_value`` is not set when calling ``nc_write``

Here I address those by 
 1. Always setting ``v%FillValue = v%missing_value``, when ``missing_value`` is ``present``
 2. set ``v%missing_set`` and ``v%FillValue_set`` to ``.false.`` when initialising a new variable in ``nc_v_init``.