### PR TITLE
Address a problem with nc_put_att in debug mode (issue #11)

### DIFF
--- a/ncio.f90
+++ b/ncio.f90
@@ -825,8 +825,6 @@ contains
 
         integer, parameter :: noerr = NF90_NOERR
 
-        ndims = size(v%dims)
-
         ! Check if variable already exists - if so, gets the varid
         stat = nf90_inq_varid(ncid, trim(v%name), v%varid)
 
@@ -843,6 +841,7 @@ contains
             else
                 ! This is a data variable
                 ! Determine ids of dimensions
+                ndims = size(v%dims)
                 allocate(dimids(ndims))
                 do i = 1, ndims
                     call nc_check ( nf90_inq_dimid(ncid, v%dims(i), dimids(i)) )


### PR DESCRIPTION
When using the debugging option (environment variable debug set to 1)
nc_put_att crashes because of an un-allocated variable. The reason for
this is that nc_put_att checks the size of v%dims before checking if v
is a coordinate or a data variable. The size of v%dims is only needed
for data variables, but the crash originates in calling nc_put_att for a
coordinate variable.

The solution is to check the size of v%dims only after making sure it's
a data variable, because v%dims is not allocated for coordinate
variables.